### PR TITLE
Fix dead SDF3 URL

### DIFF
--- a/assignments/ms1/lab2.md
+++ b/assignments/ms1/lab2.md
@@ -141,7 +141,7 @@ This is because Spoofax editors support syntactic error recovery.
 
 ### SDF3
 
-You should define your syntax in [SDF3](http://metaborg.org/wiki/sdf).
+You should define your syntax in [SDF3](http://metaborg.org/sdf3/).
 You can start by creating a new file `syntax/MiniJava.sdf3` in your MiniJava project:
 
     module MiniJava

--- a/assignments/ms1/lab3.md
+++ b/assignments/ms1/lab3.md
@@ -174,7 +174,7 @@ You can fix this by improving your templates in the syntax definition.
 The completion templates follow the indentation and line breaks from the syntax definition.
 You can hide particular placeholders from completion templates with a `hide` option or
 change a placeholder label with a `text="label"` option.
-Read the [SDF3 documentation](http://metaborg.org/wiki/sdf) on templates and placeholders for more information.
+Read the [SDF3 documentation](http://metaborg.org/sdf3/) on templates and placeholders for more information.
 
 You should improve your syntax definition in order to get readable completion templates with a consistent indentation.
 You might read on [indent styles](http://en.wikipedia.org/wiki/Indent_style) for some inspiration.


### PR DESCRIPTION
[http://metaborg.org/wiki/sdf](http://metaborg.org/wiki/sdf) has been changed to [http://metaborg.org/sdf3/](http://metaborg.org/sdf3/).
