### PR TITLE
change link to MS FAQ to point to 'faq'

### DIFF
--- a/assignments/ms1/index.md
+++ b/assignments/ms1/index.md
@@ -42,4 +42,4 @@ The [MiniJava project](http://www.cambridge.org/us/features/052182060X/)
 by Joao Cangussu, Jens Palsberg and Vidyut Samanta provides some example programs
 and an HTML version of the reference manual.
 
-We provide [answers to frequently asked questions](questions.md) for this milestone.
+We provide [answers to frequently asked questions](faq) for this milestone.


### PR DESCRIPTION
I'm not familiar to Jeckyll, so I'm not completely sure that changing the link like this will have the appropriate effect, however the link should point to /faq instead of questions.md (https://tudelft-in4303.github.io/assignments/ms1/faq) instead of (https://tudelft-in4303.github.io/assignments/ms1/questions.md)
