### PR TITLE
Fixed "Grades" section did not appear on website

### DIFF
--- a/assignments/index.md
+++ b/assignments/index.md
@@ -50,6 +50,7 @@ We do our best to hand out grading reports as quick as possible, but manual grad
 Early feedback and most parts of final grading are automated and supported by an AWS in Education Grant award.
 Each pull request triggers the launch of an Amazon EC2 instance which runs automated feedback and grading for your solution.
 Be aware that feedback might be delayed due to submissions by other students, instance limits, server problems, etc. 
+
 ## Grades
 
 We grade the first final solution of each of your assignments.


### PR DESCRIPTION
The "Grades" section does not appear on the page `http://tudelft-in4303.github.io/assignments/` due to a missing new line.
