### PR TITLE
Update lab3.md assignment text

### DIFF
--- a/assignments/ms1/lab3.md
+++ b/assignments/ms1/lab3.md
@@ -130,6 +130,20 @@ If your start symbols are not defined in the main SDF3 module, you might need to
 Typically, the pretty-printed code lacks proper indentation and line breaks.
 You can fix this by improving your templates in the syntax definition.
 The pretty-printer follows the indentation and line breaks from the syntax definition.
+So any formatting that you add to your templates will be reflected in the product of the pretty-printer.
+For instance, the following syntax-definition template:
+```
+Gammer.Lexial =
+<lexical syntax {
+ <Production*>
+}>
+```
+will transform `lexical syntax {number = "true"}` to the following pretty-printed product:
+```
+lexical syntax {
+ number = "true"
+}
+```
 
 You should improve your syntax definition in order to get readable code with a consistent indentation.
 You might read on [indent styles](http://en.wikipedia.org/wiki/Indent_style) for some inspiration.

--- a/assignments/ms1/lab3.md
+++ b/assignments/ms1/lab3.md
@@ -131,17 +131,25 @@ Typically, the pretty-printed code lacks proper indentation and line breaks.
 You can fix this by improving your templates in the syntax definition.
 The pretty-printer follows the indentation and line breaks from the syntax definition.
 So any formatting that you add to your templates will be reflected in the product of the pretty-printer.
-For instance, the following MiniJava template:
+For instance, by changing the following MiniJava template:
+```
+Statement.While = <while (<Exp>) <Statement>>
+```
+Into a template which includes layout:
 ```
 Statement.While =
 <
-while (<Exp>)
+while ( <Exp> )
     <Statement>
 >
 ```
-will transform `while(true) a = 5;` to the following pretty-printed product:
+This will transform your formatted program code:
 ```
-while (true)
+while (true) a = 5;
+```
+Into the following pretty-printed product:
+```
+while ( true )
     a = 5;
 ```
 

--- a/assignments/ms1/lab3.md
+++ b/assignments/ms1/lab3.md
@@ -131,18 +131,18 @@ Typically, the pretty-printed code lacks proper indentation and line breaks.
 You can fix this by improving your templates in the syntax definition.
 The pretty-printer follows the indentation and line breaks from the syntax definition.
 So any formatting that you add to your templates will be reflected in the product of the pretty-printer.
-For instance, the following syntax-definition template:
+For instance, the following MiniJava template:
 ```
-Gammer.Lexial =
-<lexical syntax {
- <Production*>
-}>
+Statement.While =
+<
+while (<Exp>)
+    <Statement>
+>
 ```
-will transform `lexical syntax {number = "true"}` to the following pretty-printed product:
+will transform `while(true) a = 5;` to the following pretty-printed product:
 ```
-lexical syntax {
- number = "true"
-}
+while (true)
+    a = 5;
 ```
 
 You should improve your syntax definition in order to get readable code with a consistent indentation.


### PR DESCRIPTION
Add an example on how layout in a syntax definition template is reflected in the pretty-printed output.
