### PR TITLE
#15 Fix broken links to LL/LR parsing also from nav

### DIFF
--- a/_data/subcontextmenu.yml
+++ b/_data/subcontextmenu.yml
@@ -72,12 +72,12 @@
   subcontext: generation
 
 - title: LL Parsing
-  url: /lectures/generation/LL-parsing.html
+  url: /lectures/generation/ll-parsing.html
   context: lectures
   subcontext: generation
 
 - title: LR Parsing
-  url: /lectures/generation/LR-parsing.html
+  url: /lectures/generation/lr-parsing.html
   context: lectures
   subcontext: generation
 


### PR DESCRIPTION
In addition to #15 fix the links to LL/LR parsing lectures from navigation menu.
